### PR TITLE
docs: add ffi ownership notes to header

### DIFF
--- a/include/contextdb.h
+++ b/include/contextdb.h
@@ -29,8 +29,9 @@ bool contextdb_count(const ContextDBHandle *handle, size_t *out_count);
 
 // Returns a newly allocated results array owned by the caller.
 // The length is written to out_len (must be non-NULL). Free with
-// contextdb_query_results_free(results, *out_len). Callers must pass
-// valid pointers/lengths for meaning_ptr/meaning_len.
+// contextdb_query_results_free(results, *out_len). Each result's
+// expression string is also owned by the array and freed there.
+// Callers must pass valid handle/pointers and matching lengths.
 ContextDBQueryResult *contextdb_query_meaning(const ContextDBHandle *handle,
                                              const float *meaning_ptr,
                                              size_t meaning_len,
@@ -40,15 +41,16 @@ ContextDBQueryResult *contextdb_query_meaning(const ContextDBHandle *handle,
 
 // Returns a newly allocated results array owned by the caller.
 // The length is written to out_len (must be non-NULL). Free with
-// contextdb_query_results_free(results, *out_len). Callers must pass
-// valid pointers/lengths for expression strings when required.
+// contextdb_query_results_free(results, *out_len). Each result's
+// expression string is also owned by the array and freed there.
+// Callers must pass valid handle/pointers and matching lengths.
 ContextDBQueryResult *contextdb_query_expression_contains(const ContextDBHandle *handle,
                                                          const char *expression,
                                                          size_t limit,
                                                          size_t *out_len);
 
 // Frees a results array (and any associated result strings) returned by
-// contextdb_query_*.
+// contextdb_query_*. len must match the out_len returned by the query.
 void contextdb_query_results_free(ContextDBQueryResult *results, size_t len);
 
 // Returns a newly allocated, null-terminated error message string owned

--- a/include/contextdb.h
+++ b/include/contextdb.h
@@ -27,6 +27,10 @@ bool contextdb_insert(ContextDBHandle *handle,
 
 bool contextdb_count(const ContextDBHandle *handle, size_t *out_count);
 
+// Returns a newly allocated results array owned by the caller.
+// The length is written to out_len (must be non-NULL). Free with
+// contextdb_query_results_free(results, *out_len). Callers must pass
+// valid pointers/lengths for meaning_ptr/meaning_len.
 ContextDBQueryResult *contextdb_query_meaning(const ContextDBHandle *handle,
                                              const float *meaning_ptr,
                                              size_t meaning_len,
@@ -34,14 +38,24 @@ ContextDBQueryResult *contextdb_query_meaning(const ContextDBHandle *handle,
                                              size_t limit,
                                              size_t *out_len);
 
+// Returns a newly allocated results array owned by the caller.
+// The length is written to out_len (must be non-NULL). Free with
+// contextdb_query_results_free(results, *out_len). Callers must pass
+// valid pointers/lengths for expression strings when required.
 ContextDBQueryResult *contextdb_query_expression_contains(const ContextDBHandle *handle,
                                                          const char *expression,
                                                          size_t limit,
                                                          size_t *out_len);
 
+// Frees a results array (and any associated result strings) returned by
+// contextdb_query_*.
 void contextdb_query_results_free(ContextDBQueryResult *results, size_t len);
 
+// Returns a newly allocated, null-terminated error message string owned
+// by the caller. Free with contextdb_string_free.
 char *contextdb_last_error_message(void);
+// Frees a string returned by contextdb_last_error_message (or other FFI
+// string-returning APIs). Pointer must be valid or NULL.
 void contextdb_string_free(char *ptr);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Resolves #2 

## Summary
- document FFI pointer ownership/lifetimes in the C header
- note caller requirements for valid pointers/lengths
- clarify that query result strings are freed with the results array

## Testing
- cargo test