### PR TITLE
test: add ffi smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run all tests
         run: cargo test --all-targets --verbose
 
+      - name: Run all tests (ffi feature)
+        run: cargo test --all-targets --features ffi --verbose
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -391,6 +391,17 @@ mod tests {
 
 		unsafe {
 			contextdb_query_results_free(results, out_len);
+		}
+
+		let mut meaning_len = 0usize;
+		let meaning_results = unsafe {
+			contextdb_query_meaning(handle, meaning.as_ptr(), meaning.len(), 0.0, 10, &mut meaning_len)
+		};
+		assert!(!meaning_results.is_null(), "contextdb_query_meaning returned null");
+		assert!(meaning_len >= 1, "expected at least one meaning result");
+
+		unsafe {
+			contextdb_query_results_free(meaning_results, meaning_len);
 			contextdb_close(handle);
 		}
 	}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -373,12 +373,7 @@ mod tests {
 		let meaning = [0.25f32, 0.5f32, 0.75f32];
 
 		let inserted = unsafe {
-			contextdb_insert(
-				handle,
-				expression.as_ptr(),
-				meaning.as_ptr(),
-				meaning.len(),
-			)
+			contextdb_insert(handle, expression.as_ptr(), meaning.as_ptr(), meaning.len())
 		};
 		assert!(inserted, "contextdb_insert failed");
 
@@ -386,7 +381,10 @@ mod tests {
 		let results = unsafe {
 			contextdb_query_expression_contains(handle, expression.as_ptr(), 10, &mut out_len)
 		};
-		assert!(!results.is_null(), "contextdb_query_expression_contains returned null");
+		assert!(
+			!results.is_null(),
+			"contextdb_query_expression_contains returned null"
+		);
 		assert!(out_len >= 1, "expected at least one result");
 
 		unsafe {
@@ -395,9 +393,19 @@ mod tests {
 
 		let mut meaning_len = 0usize;
 		let meaning_results = unsafe {
-			contextdb_query_meaning(handle, meaning.as_ptr(), meaning.len(), 0.0, 10, &mut meaning_len)
+			contextdb_query_meaning(
+				handle,
+				meaning.as_ptr(),
+				meaning.len(),
+				0.0,
+				10,
+				&mut meaning_len,
+			)
 		};
-		assert!(!meaning_results.is_null(), "contextdb_query_meaning returned null");
+		assert!(
+			!meaning_results.is_null(),
+			"contextdb_query_meaning returned null"
+		);
 		assert!(meaning_len >= 1, "expected at least one meaning result");
 
 		unsafe {


### PR DESCRIPTION
Resolves #4 

## Summary
- add a minimal FFI smoke test for the C API round-trip
- run FFI tests in CI with `--features ffi`

## Testing
- cargo test --all-targets --features ffi