### PR TITLE
ci: build release cli with feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,11 @@ jobs:
 
       - name: Build (cross)
         if: matrix.cross
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }} --bin contextdb --features cli
 
       - name: Build (native)
         if: ${{ !matrix.cross }}
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --bin contextdb --features cli
 
       - name: Get version
         id: version


### PR DESCRIPTION
Resolves #5 

## Summary
- build release artifacts with `--features cli` and `--bin contextdb`
- keep artifact naming consistent with install script expectations

## Testing
- not run (workflow change)