### PR TITLE
chore: add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,14 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         pkg-config \
         libsqlite3-dev \
+        sqlite3 \
         ca-certificates \
+        curl \
+        git \
+        jq \
+        ripgrep \
     && rm -rf /var/lib/apt/lists/*
+
+RUN rustup component add rustfmt clippy
 
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.78-bullseye
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libsqlite3-dev \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "ContextDB",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "cargo fetch",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Rust devcontainer with SQLite build deps
- include common CLI tools and Rust components (rustfmt, clippy)

## Testing
- not run (devcontainer config)