### PR TITLE
Benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +158,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -225,6 +264,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "criterion",
  "dialoguer",
  "dirs",
  "indicatif",
@@ -243,6 +283,73 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dialoguer"
@@ -277,6 +384,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -348,6 +461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +501,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -416,10 +546,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -557,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +734,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -638,6 +822,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_users"
@@ -711,6 +915,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -859,6 +1072,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +1128,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -967,6 +1200,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1217,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ ffi = []
 
 [dev-dependencies]
 anyhow = "1.0"
+criterion = "0.5"
+
+[[bench]]
+name = "contextdb_bench"
+harness = false
 
 [profile.release]
 lto = true

--- a/benches/contextdb_bench.rs
+++ b/benches/contextdb_bench.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use contextdb::{ContextDB, ContextFilter, Entry, ExpressionFilter, Query};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use serde_json::json;
 
 const DIMENSIONS: usize = 128;
@@ -88,10 +88,8 @@ fn bench_query_expression(c: &mut Criterion) {
 
 fn bench_query_context(c: &mut Criterion) {
 	let db = populate_db(QUERY_COUNT, DIMENSIONS);
-	let query = Query::new().with_context(ContextFilter::PathEquals(
-		"/group".to_string(),
-		json!("a"),
-	));
+	let query =
+		Query::new().with_context(ContextFilter::PathEquals("/group".to_string(), json!("a")));
 
 	c.bench_function("query_context_5k", |b| {
 		b.iter(|| {

--- a/benches/contextdb_bench.rs
+++ b/benches/contextdb_bench.rs
@@ -1,0 +1,111 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use contextdb::{ContextDB, ContextFilter, Entry, ExpressionFilter, Query};
+use serde_json::json;
+
+const DIMENSIONS: usize = 128;
+const INSERT_COUNT: usize = 1_000;
+const QUERY_COUNT: usize = 5_000;
+
+fn make_vector(seed: usize, dim: usize) -> Vec<f32> {
+	(0..dim)
+		.map(|i| {
+			let base = (seed.wrapping_add(i * 13) % 101) as f32;
+			base / 101.0
+		})
+		.collect()
+}
+
+fn make_entry(index: usize, dim: usize) -> Entry {
+	let expression = if index % 10 == 0 {
+		format!("alpha entry {index}")
+	} else {
+		format!("beta entry {index}")
+	};
+	let context = if index % 2 == 0 {
+		json!({"group": "a", "index": index})
+	} else {
+		json!({"group": "b", "index": index})
+	};
+
+	Entry::new(make_vector(index, dim), expression).with_context(context)
+}
+
+fn build_entries(count: usize, dim: usize) -> Vec<Entry> {
+	(0..count).map(|i| make_entry(i, dim)).collect()
+}
+
+fn populate_db(count: usize, dim: usize) -> ContextDB {
+	let mut db = ContextDB::in_memory().expect("in-memory db");
+	let entries = build_entries(count, dim);
+	for entry in &entries {
+		db.insert(entry).expect("insert entry");
+	}
+	db
+}
+
+fn bench_insert_batch(c: &mut Criterion) {
+	let entries = build_entries(INSERT_COUNT, DIMENSIONS);
+	c.bench_function("insert_1k", |b| {
+		b.iter_batched(
+			|| ContextDB::in_memory().expect("in-memory db"),
+			|mut db| {
+				for entry in &entries {
+					db.insert(entry).expect("insert entry");
+				}
+				black_box(db.count().expect("count entries"));
+			},
+			BatchSize::LargeInput,
+		);
+	});
+}
+
+fn bench_query_meaning(c: &mut Criterion) {
+	let db = populate_db(QUERY_COUNT, DIMENSIONS);
+	let query_vector = make_vector(QUERY_COUNT / 2, DIMENSIONS);
+	let query = Query::new()
+		.with_meaning(query_vector, Some(0.8))
+		.with_limit(50);
+
+	c.bench_function("query_meaning_5k", |b| {
+		b.iter(|| {
+			let results = db.query(&query).expect("query results");
+			black_box(results.len());
+		});
+	});
+}
+
+fn bench_query_expression(c: &mut Criterion) {
+	let db = populate_db(QUERY_COUNT, DIMENSIONS);
+	let query = Query::new().with_expression(ExpressionFilter::Contains("alpha".to_string()));
+
+	c.bench_function("query_expression_5k", |b| {
+		b.iter(|| {
+			let results = db.query(&query).expect("query results");
+			black_box(results.len());
+		});
+	});
+}
+
+fn bench_query_context(c: &mut Criterion) {
+	let db = populate_db(QUERY_COUNT, DIMENSIONS);
+	let query = Query::new().with_context(ContextFilter::PathEquals(
+		"/group".to_string(),
+		json!("a"),
+	));
+
+	c.bench_function("query_context_5k", |b| {
+		b.iter(|| {
+			let results = db.query(&query).expect("query results");
+			black_box(results.len());
+		});
+	});
+}
+
+criterion_group!(
+	benches,
+	bench_insert_batch,
+	bench_query_meaning,
+	bench_query_expression,
+	bench_query_context
+);
+criterion_main!(benches);


### PR DESCRIPTION
This pull request adds comprehensive benchmarking for the `ContextDB` crate using the Criterion framework. The main changes include introducing a new benchmark suite that measures the performance of batch inserts and different query types, as well as updating dependencies to support benchmarking.

**Benchmarking infrastructure:**

* Added `criterion` as a development dependency in `Cargo.toml` and configured a new benchmark target `contextdb_bench` with harness disabled for Criterion compatibility.
* Created `benches/contextdb_bench.rs` to define benchmarks for batch inserts and queries on `ContextDB`, including setup functions for generating test data and measuring performance of meaning, expression, and context-based queries.