### PR TITLE
feat: add SwiftPM binary package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude/settings.*
 /target
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/settings.*
 /target
 /dist
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ContextDB",
+    platforms: [
+        .iOS(.v14),
+        .macOS(.v12),
+    ],
+    products: [
+        .library(
+            name: "ContextDB",
+            targets: ["ContextDB"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "ContextDB",
+            path: "dist/ContextDB.xcframework"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ContextDB is an embedded database designed for LLM-powered applications that nee
 - [Why ContextDB?](./docs/why.md)
 - [Installation](./docs/installation.md)
     - [iOS](./docs/ios.md)
+    - [Swift Package](./docs/swiftpm.md)
 - [Quickstart](./docs/quickstart.md)
 - [CLI Guide](./docs/cli.md)
 - [Core Concepts](./docs/concepts.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ A map of the documentation set and where to start.
 ## Integrations
 
 - `ios.md` - iOS integration via the C FFI layer
+- `swiftpm.md` - Swift Package distribution (XCFramework)
 - `base.md` - Inspecting ContextDB SQLite files in Base (SQLite)
 
 ## Contributing

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -2,6 +2,7 @@
 
 ## Overview
 Use ContextDB from iOS via the C FFI layer.
+If you prefer Swift Package Manager, see [swiftpm.md](swiftpm.md).
 
 ## When to use
 - You are embedding ContextDB in an iOS app.

--- a/docs/swiftpm.md
+++ b/docs/swiftpm.md
@@ -1,0 +1,49 @@
+# Swift Package Distribution
+
+## Overview
+ContextDB ships a Swift Package that wraps the Rust static library via an XCFramework.
+The package is binary-based so you can import `ContextDB` directly in Swift.
+
+## Build the XCFramework
+Install the required Rust targets:
+
+```sh
+rustup target add \
+  aarch64-apple-ios \
+  aarch64-apple-ios-sim \
+  x86_64-apple-ios \
+  aarch64-apple-darwin \
+  x86_64-apple-darwin
+```
+
+Build the XCFramework for SwiftPM:
+
+```sh
+scripts/build_spm_xcframework.sh
+```
+
+This writes `dist/ContextDB.xcframework`.
+
+## Use the Swift Package (local)
+In Xcode, add the repo as a **local package** and select the `ContextDB` product.
+You can also add it in a `Package.swift` dependency:
+
+```swift
+.package(path: "/path/to/ContextDB")
+```
+
+Then:
+
+```swift
+import ContextDB
+```
+
+## Publishing
+If you want to publish a remote Swift Package:
+1. Zip `dist/ContextDB.xcframework`.
+2. Upload the zip to a GitHub release.
+3. Update `Package.swift` to use a `binaryTarget(url:checksum:)` with the release URL.
+
+## Notes
+- The module map lives in `include/module.modulemap`.
+- The FFI header is `include/contextdb.h`.

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -1,0 +1,4 @@
+module ContextDB {
+    header "contextdb.h"
+    export *
+}

--- a/scripts/build_spm_xcframework.sh
+++ b/scripts/build_spm_xcframework.sh
@@ -14,10 +14,16 @@ FEATURES="ffi"
 LIB_NAME="contextdb"
 HEADER_DIR="$ROOT_DIR/include"
 OUTPUT_DIR="$ROOT_DIR/dist/ContextDB.xcframework"
+MACOS_UNIVERSAL_DIR="$ROOT_DIR/target/universal-macos"
+MACOS_UNIVERSAL_LIB="$MACOS_UNIVERSAL_DIR/lib${LIB_NAME}.a"
+IOS_SIM_UNIVERSAL_DIR="$ROOT_DIR/target/universal-ios-sim"
+IOS_SIM_UNIVERSAL_LIB="$IOS_SIM_UNIVERSAL_DIR/lib${LIB_NAME}.a"
 
 cd "$ROOT_DIR"
 
 mkdir -p "$ROOT_DIR/dist"
+mkdir -p "$MACOS_UNIVERSAL_DIR"
+mkdir -p "$IOS_SIM_UNIVERSAL_DIR"
 
 for target in "${TARGETS[@]}"; do
   cargo build --release --lib --features "$FEATURES" --target "$target"
@@ -31,12 +37,22 @@ done
 echo "Packaging XCFramework..."
 rm -rf "$OUTPUT_DIR"
 
+echo "Creating macOS universal static library..."
+lipo -create \
+  "target/aarch64-apple-darwin/release/lib${LIB_NAME}.a" \
+  "target/x86_64-apple-darwin/release/lib${LIB_NAME}.a" \
+  -output "$MACOS_UNIVERSAL_LIB"
+
+echo "Creating iOS simulator universal static library..."
+lipo -create \
+  "target/aarch64-apple-ios-sim/release/lib${LIB_NAME}.a" \
+  "target/x86_64-apple-ios/release/lib${LIB_NAME}.a" \
+  -output "$IOS_SIM_UNIVERSAL_LIB"
+
 xcodebuild -create-xcframework \
   -library "target/aarch64-apple-ios/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
-  -library "target/aarch64-apple-ios-sim/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
-  -library "target/x86_64-apple-ios/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
-  -library "target/aarch64-apple-darwin/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
-  -library "target/x86_64-apple-darwin/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -library "$IOS_SIM_UNIVERSAL_LIB" -headers "$HEADER_DIR" \
+  -library "$MACOS_UNIVERSAL_LIB" -headers "$HEADER_DIR" \
   -output "$OUTPUT_DIR"
 
 echo "XCFramework written to $OUTPUT_DIR"

--- a/scripts/build_spm_xcframework.sh
+++ b/scripts/build_spm_xcframework.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGETS=(
+  "aarch64-apple-ios"
+  "aarch64-apple-ios-sim"
+  "x86_64-apple-ios"
+  "aarch64-apple-darwin"
+  "x86_64-apple-darwin"
+)
+
+FEATURES="ffi"
+LIB_NAME="contextdb"
+HEADER_DIR="$ROOT_DIR/include"
+OUTPUT_DIR="$ROOT_DIR/dist/ContextDB.xcframework"
+
+cd "$ROOT_DIR"
+
+mkdir -p "$ROOT_DIR/dist"
+
+for target in "${TARGETS[@]}"; do
+  cargo build --release --lib --features "$FEATURES" --target "$target"
+  if [[ ! -f "target/$target/release/lib${LIB_NAME}.a" ]]; then
+    echo "Expected static library missing for $target" >&2
+    exit 1
+  fi
+  echo "Built $target"
+done
+
+echo "Packaging XCFramework..."
+rm -rf "$OUTPUT_DIR"
+
+xcodebuild -create-xcframework \
+  -library "target/aarch64-apple-ios/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -library "target/aarch64-apple-ios-sim/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -library "target/x86_64-apple-ios/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -library "target/aarch64-apple-darwin/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -library "target/x86_64-apple-darwin/release/lib${LIB_NAME}.a" -headers "$HEADER_DIR" \
+  -output "$OUTPUT_DIR"
+
+echo "XCFramework written to $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add SwiftPM binary package entrypoint and module map
- add XCFramework build script for iOS + macOS slices
- document SwiftPM usage and link from docs

## Testing
- Not run (requires Rust/iOS toolchains and Xcode)