### PR TITLE
CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +126,17 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -261,6 +287,7 @@ name = "contextdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
  "colored",
@@ -269,11 +296,13 @@ dependencies = [
  "dirs",
  "indicatif",
  "ndarray",
+ "predicates",
  "regex",
  "rusqlite",
  "serde",
  "serde_json",
  "tabled",
+ "tempfile",
  "thiserror",
  "uuid",
 ]
@@ -365,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +465,15 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -662,6 +706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +818,36 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1052,6 +1132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1214,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ ffi = []
 [dev-dependencies]
 anyhow = "1.0"
 criterion = "0.5"
+assert_cmd = "2.0"
+predicates = "3.1"
+tempfile = "3.10"
 
 [[bench]]
 name = "contextdb_bench"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "cli")]
 
+use assert_cmd::cargo::cargo_bin_cmd;
 use assert_cmd::Command;
 use contextdb::{ContextDB, Entry};
 use predicates::prelude::*;
@@ -12,7 +13,7 @@ fn temp_db_path() -> (TempDir, std::path::PathBuf) {
 }
 
 fn cmd_bin() -> Command {
-	let mut cmd = Command::cargo_bin("contextdb").expect("binary built");
+	let mut cmd = cargo_bin_cmd!("contextdb");
 	cmd.env("NO_COLOR", "1").env("CLICOLOR", "0");
 	cmd
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "cli")]
+
+use assert_cmd::Command;
+use contextdb::{ContextDB, Entry};
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn temp_db_path() -> (TempDir, std::path::PathBuf) {
+	let temp_dir = TempDir::new().expect("tempdir created");
+	let db_path = temp_dir.path().join("contextdb.db");
+	(temp_dir, db_path)
+}
+
+fn cmd_bin() -> Command {
+	let mut cmd = Command::cargo_bin("contextdb").expect("binary built");
+	cmd.env("NO_COLOR", "1").env("CLICOLOR", "0");
+	cmd
+}
+
+#[test]
+fn cli_init_creates_db() {
+	let (_temp_dir, db_path) = temp_db_path();
+
+	cmd_bin()
+		.args(["init", db_path.to_str().unwrap()])
+		.assert()
+		.success()
+		.stdout(predicate::str::contains("Created database"));
+
+	assert!(db_path.exists(), "database file should exist");
+}
+
+#[test]
+fn cli_list_shows_entries_plain() {
+	let (_temp_dir, db_path) = temp_db_path();
+	let mut db = ContextDB::new(&db_path).expect("db created");
+	let entry = Entry::new(vec![0.1, 0.2, 0.3], "CLI list entry".to_string());
+	let entry_id_prefix = entry.id.to_string()[..8].to_string();
+	db.insert(&entry).expect("entry inserted");
+
+	cmd_bin()
+		.args([
+			"list",
+			db_path.to_str().unwrap(),
+			"--limit",
+			"5",
+			"--format",
+			"plain",
+		])
+		.assert()
+		.success()
+		.stdout(predicate::str::contains(&entry_id_prefix))
+		.stdout(predicate::str::contains("CLI list entry"));
+}
+
+#[test]
+fn cli_search_finds_entries_json() {
+	let (_temp_dir, db_path) = temp_db_path();
+	let mut db = ContextDB::new(&db_path).expect("db created");
+	let entry = Entry::new(vec![0.3, 0.4, 0.5], "Searchable onion note".to_string());
+	let entry_id = entry.id.to_string();
+	db.insert(&entry).expect("entry inserted");
+
+	cmd_bin()
+		.args([
+			"search",
+			db_path.to_str().unwrap(),
+			"onion",
+			"--format",
+			"json",
+		])
+		.assert()
+		.success()
+		.stdout(predicate::str::contains("Searchable onion note"))
+		.stdout(predicate::str::contains(&entry_id));
+}
+
+#[test]
+fn cli_show_accepts_partial_id() {
+	let (_temp_dir, db_path) = temp_db_path();
+	let mut db = ContextDB::new(&db_path).expect("db created");
+	let entry = Entry::new(vec![0.9, 0.1, 0.2], "Partial ID entry".to_string());
+	let entry_id = entry.id.to_string();
+	let entry_prefix = entry_id[..8].to_string();
+	db.insert(&entry).expect("entry inserted");
+
+	cmd_bin()
+		.args(["show", db_path.to_str().unwrap(), &entry_prefix])
+		.assert()
+		.success()
+		.stdout(predicate::str::contains("Entry Details"))
+		.stdout(predicate::str::contains(&entry_id))
+		.stdout(predicate::str::contains("Partial ID entry"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,7 +23,8 @@ fn cli_init_creates_db() {
 	let (_temp_dir, db_path) = temp_db_path();
 
 	cmd_bin()
-		.args(["init", db_path.to_str().unwrap()])
+		.arg("init")
+		.arg(&db_path)
 		.assert()
 		.success()
 		.stdout(predicate::str::contains("Created database"));
@@ -40,14 +41,9 @@ fn cli_list_shows_entries_plain() {
 	db.insert(&entry).expect("entry inserted");
 
 	cmd_bin()
-		.args([
-			"list",
-			db_path.to_str().unwrap(),
-			"--limit",
-			"5",
-			"--format",
-			"plain",
-		])
+		.arg("list")
+		.arg(&db_path)
+		.args(["--limit", "5", "--format", "plain"])
 		.assert()
 		.success()
 		.stdout(predicate::str::contains(&entry_id_prefix))
@@ -63,13 +59,10 @@ fn cli_search_finds_entries_json() {
 	db.insert(&entry).expect("entry inserted");
 
 	cmd_bin()
-		.args([
-			"search",
-			db_path.to_str().unwrap(),
-			"onion",
-			"--format",
-			"json",
-		])
+		.arg("search")
+		.arg(&db_path)
+		.arg("onion")
+		.args(["--format", "json"])
 		.assert()
 		.success()
 		.stdout(predicate::str::contains("Searchable onion note"))
@@ -86,7 +79,9 @@ fn cli_show_accepts_partial_id() {
 	db.insert(&entry).expect("entry inserted");
 
 	cmd_bin()
-		.args(["show", db_path.to_str().unwrap(), &entry_prefix])
+		.arg("show")
+		.arg(&db_path)
+		.arg(&entry_prefix)
 		.assert()
 		.success()
 		.stdout(predicate::str::contains("Entry Details"))


### PR DESCRIPTION
This pull request adds a new test suite for the CLI functionality of the `contextdb` crate and introduces supporting dependencies for CLI testing. The main changes include new integration tests that verify CLI commands and updates to development dependencies to enable these tests.

**CLI Testing Enhancements:**

* Added a new file `tests/cli.rs` containing integration tests for the CLI, covering database initialization, listing entries, searching, and showing entries by partial ID.

**Development Dependency Updates:**

* Added `assert_cmd`, `predicates`, and `tempfile` to `[dev-dependencies]` in `Cargo.toml` to support CLI testing and temporary file management.